### PR TITLE
Add fast last(), last_mut() and upper_bound() operations…

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,11 @@ use std::vec;
 /// ```
 #[derive(Clone)]
 pub struct VecMap<V> {
+    // If the `VecMap` contains `(k,val)`, then `v[k] == Some(val)`.
+    // If the map contains no element at key `k`, then either `v[k] == None`
+    // or `v.len() <= k`.
+    // Additionally, if `v.len() > 0`, then `v[v.len()-1] == Some(val)` for
+    // some value `val`.
     v: Vec<Option<V>>,
 }
 
@@ -257,6 +262,28 @@ impl<V> VecMap<V> {
             iter: self.v.iter_mut()
         }
     }
+    
+    /// Returns the key of the largest item plus one. This is a fast, constant
+    /// time, operation.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use vec_map::VecMap;
+    /// 
+    /// let mut map = VecMap::new();
+    /// map.insert(7, "seven");
+    /// map.insert(3, "three");
+    /// assert_eq!(map.upper_bound(), 8);
+    /// map.remove(7);
+    /// assert_eq!(map.upper_bound(), 4);
+    /// map.remove(3);
+    /// assert_eq!(map.upper_bound(), 0);
+    /// ```
+    pub fn upper_bound(&self) -> usize {
+        // We require that v.last() is not None except when v is empty
+        self.v.len()
+    }
 
     /// Moves all elements from `other` into the map while overwriting existing keys.
     ///
@@ -340,6 +367,13 @@ impl<V> VecMap<V> {
 
         // Move elements beginning with `start_index` from `self` into `other`
         other.v.extend(self.v[start_index..].iter_mut().map(|el| el.take()));
+        
+        // Reduce the length of self.v (though not the capacity) as required
+        let mut i = start_index;
+        while i > 0 && self.v[i - 1].is_none() {
+            i -= 1;
+        }
+        self.v.truncate(i);
 
         other
     }
@@ -482,6 +516,51 @@ impl<V> VecMap<V> {
             None
         }
     }
+    
+    /// Returns a reference to the last value of the map, or `None` if the map
+    /// is empty.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use vec_map::VecMap;
+    /// 
+    /// let mut map = VecMap::new();
+    /// assert_eq!(map.last(), None);
+    /// map.insert(5, "five");
+    /// map.insert(10, "ten");
+    /// assert_eq!(map.last(), Some(&"ten"));
+    /// ```
+    pub fn last(&self) -> Option<&V> {
+        self.v.last().and_then(|x| match *x {
+            Some(ref value) => Some(value),
+            None => None
+        })
+    }
+    
+    /// Returns a mutable reference to the last value of the map, or `None` if
+    /// the map is empty.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// use vec_map::VecMap;
+    /// 
+    /// let mut map = VecMap::new();
+    /// assert_eq!(map.last_mut(), None);
+    /// map.insert(5, "five");
+    /// map.insert(10, "ten");
+    /// if let Some(x) = map.last_mut() {
+    ///     *x = "five times two";
+    /// }
+    /// assert_eq!(map.get(10), Some(&"five times two"));
+    /// ```
+    pub fn last_mut(&mut self) -> Option<&mut V> {
+        self.v.last_mut().and_then(|x| match *x {
+            Some(ref mut value) => Some(value),
+            None => None
+        })
+    }
 
     /// Inserts a key-value pair into the map. If the key already had a value
     /// present in the map, that value is returned. Otherwise, `None` is returned.
@@ -524,8 +603,16 @@ impl<V> VecMap<V> {
         if key >= self.v.len() {
             return None;
         }
-        let result = &mut self.v[key];
-        result.take()
+        let result = self.v[key].take();
+        
+        // Reduce the length of self.v (though not the capacity) as required
+        let mut i = self.v.len();
+        while i > 0 && self.v[i - 1].is_none() {
+            i -= 1;
+        }
+        self.v.truncate(i);
+        
+        result
     }
 
     /// Gets the given key's corresponding entry in the map for in-place manipulation.
@@ -1204,9 +1291,12 @@ mod test {
         a.insert(4, "d");
 
         let b = a.split_off(3);
-
+        
         assert_eq!(a.len(), 2);
         assert_eq!(b.len(), 2);
+        
+        assert_eq!(a.upper_bound(), 3);
+        assert_eq!(b.upper_bound(), 5);
 
         assert_eq!(a[1], "a");
         assert_eq!(a[2], "b");
@@ -1225,6 +1315,8 @@ mod test {
 
         assert_eq!(a.len(), 0);
         assert_eq!(b.len(), 4);
+        assert_eq!(a.upper_bound(), 0);
+        assert_eq!(b.upper_bound(), 5);
         assert_eq!(b[1], "a");
         assert_eq!(b[2], "b");
         assert_eq!(b[3], "c");
@@ -1241,6 +1333,8 @@ mod test {
 
         assert_eq!(a.len(), 4);
         assert_eq!(b.len(), 0);
+        assert_eq!(a.upper_bound(), 5);
+        assert_eq!(b.upper_bound(), 0);
         assert_eq!(a[1], "a");
         assert_eq!(a[2], "b");
         assert_eq!(a[3], "c");


### PR DESCRIPTION
…via additional constraints on internal vec

I wrote this as a proof of concept to satisfy a use-case of mine (actually, in my use case elements are never removed so the implementation could be simpler).

This adds three new operations which should all be constant time, at the cost of potentially making `remove()` and `split_off()` `O(n)` operations. Thoughts?

The new operations could of course be added without the other changes, but in that case they would merely be convenience wrappers.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/contain-rs/vec-map/12)

<!-- Reviewable:end -->
