### PR TITLE
Adding nightly serde support for VecMap under "eders" feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
     - rust: stable
     - rust: nightly
       env: FEATURES="--features nightly"
+    - rust: nightly
+      env: FEATURES="--features eders"
 script:
     - cargo build $FEATURES
     - cargo test $FEATURES

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,3 +38,8 @@ readme = "README.md"
 
 [features]
 nightly = []
+eders = ["serde", "serde_macros"]
+
+[dependencies]
+serde = { version = "0.6", optional = true }
+serde_macros = { version = "0.6", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,12 @@
 
 #![cfg_attr(feature = "nightly", feature(drain))]
 
+// optional serde support
+#![cfg_attr(feature = "eders", feature(const_fn, custom_derive, plugin))]
+#![cfg_attr(feature = "eders", plugin(serde_macros))]
+#[cfg(feature = "eders")]
+extern crate serde;
+
 use self::Entry::*;
 
 use std::cmp::max;
@@ -58,6 +64,7 @@ use std::vec;
 /// assert!(months.is_empty());
 /// ```
 #[derive(Clone)]
+#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
 pub struct VecMap<V> {
     v: Vec<Option<V>>,
 }
@@ -1457,5 +1464,14 @@ mod test {
         assert_eq!(a[&1], "one");
         assert_eq!(a[&2], "two");
         assert_eq!(a[&3], "three");
+    }
+
+    #[test]
+    #[cfg(feature = "eders")]
+    fn test_serde() {
+        use serde::{Serialize, Deserialize};
+        fn impls_serde_traits<S: Serialize + Deserialize>() {}
+
+        impls_serde_traits::<VecMap<u32>>();
     }
 }


### PR DESCRIPTION
I'm working on adding [serde](https://github.com/serde-rs/serde) support for [rust-bio](https://github.com/rust-bio/rust-bio) because many of the data structures used for bioinformatics can get quite large (many GB), and recomputing them takes a long time. rust-bio currently uses vec_map as a dependency for one of its index types, and I can't add serialization/deserialization to that type with serde without VecMap having it too.

This PR adds optional (under a feature flag) serde support for VecMap. Is this something you'd consider incorporating into the crate? The feature flag approach is how the maintainer of rust-bio preferred the implementation, so that's what I've used here to avoid using the buildscript approach that's usable on stable. My only gripe with this method is that I don't want to overload the nightly feature flag vec_map already uses, and I can't have a feature with the same name as a crate it depends on, so I chose the crate name's reverse. If this support is something you'd like to merge but would prefer a different feature flag (or would prefer to use a buildscript for the optional support), I'm more than happy to make any changes.

For context on the process of adding serde to rust-bio:

https://github.com/rust-bio/rust-bio/pull/33
https://github.com/rust-bio/rust-bio/pull/34

Also, as a more general question, I see that the same org owns the [bit-set](https://github.com/contain-rs/bit-set) and [bit-vec](https://github.com/contain-rs/bit-vec) repos which are both dependencies in other rust-bio data structures, would you be willing to merge similar support for those as well?
