### PR TITLE
Use the same lifetime for into_iter_covariant.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ readme = "README.md"
 eders = ["serde", "serde_macros"]
 
 [dependencies]
-serde = { version = "0.7", optional = true }
-serde_macros = { version = "0.7", optional = true }
+serde = { version = "0.8", optional = true }
+serde_macros = { version = "0.8", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -949,7 +949,7 @@ impl<V> DoubleEndedIterator for IntoIter<V> {
 fn assert_properties() {
     fn vec_map_covariant<'a, T>(map: VecMap<&'static T>) -> VecMap<&'a T> { map }
 
-    fn into_iter_covariant<'a, T>(iter: IntoIter<&'static T>) -> IntoIter<&'a T> { iter }
+    fn into_iter_covariant<T>(iter: IntoIter<T>) -> IntoIter<T> { iter }
 
     fn iter_covariant<'i, 'a, T>(iter: Iter<'i, &'static T>) -> Iter<'i, &'a T> { iter }
 


### PR DESCRIPTION
This no longer compiles with rustc 1.12 beta. Removing the
conversion to a non-static lifetime works on both 1.11 stable
and 1.12 beta.
