### PR TITLE
Introduce feature "serde" for enabling serde serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ keywords = ["data-structures", "collections", "vecmap", "vec_map", "contain-rs"]
 readme = "README.md"
 
 [features]
-eders = ["serde", "serde_derive"]
+# This feature is kept for backwards compatibility. Use feature "serde" instead.
+eders = [ "serde" ]
 
 [dependencies]
-serde = { version = "1.0", optional = true }
-serde_derive = { version = "1.0", optional = true }
+serde = { version = "1.0", features = [ "derive" ], optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,9 @@
 //! are O(highest integer key).
 
 // optional serde support
-#[cfg(feature = "eders")]
-extern crate serde;
-#[cfg(feature = "eders")]
+#[cfg(feature = "serde")]
 #[macro_use]
-extern crate serde_derive;
+extern crate serde;
 
 use self::Entry::*;
 
@@ -63,7 +61,7 @@ use std::vec;
 /// months.clear();
 /// assert!(months.is_empty());
 /// ```
-#[cfg_attr(feature = "eders", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct VecMap<V> {
     n: usize,
     v: Vec<Option<V>>,
@@ -1610,7 +1608,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "eders")]
+    #[cfg(feature = "serde")]
     fn test_serde() {
         use serde::{Serialize, Deserialize};
         fn impls_serde_traits<'de, S: Serialize + Deserialize<'de>>() {}


### PR DESCRIPTION
The old feature "eders" is kept for backwards compability.

Fixes #38
Fixes #29